### PR TITLE
(fix) updateContext and parseQuery middlewares

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,14 +2,15 @@ const Movies = require('../data/films.json')
 
 const updateContext = (ctx, next) => {
   ctx.state.Movies = Movies
-  next()
+
+  return next()
 }
 
 const parseQuery = (ctx, next) => {
   ctx.query.offset = (ctx.query.offset && parseInt(ctx.query.offset, 10)) || 0
   ctx.query.limit = (ctx.query.limit && parseInt(ctx.query.limit, 10)) || 10
 
-  next()
+  return next()
 }
 
 module.exports = {


### PR DESCRIPTION
For some reason, the server stopped working for me. An investigation led me to custom middlewares `updateContext` and `parseQuery`. [Looks like](https://github.com/koajs/koa/blob/master/docs/guide.md#writing-middleware) `next()` must be returned from the middleware function. Have no idea how it worked before.

I have Node.js 10.14.1